### PR TITLE
Change grid size to max width 1400px

### DIFF
--- a/scss/bootstrap/_variables.scss
+++ b/scss/bootstrap/_variables.scss
@@ -211,10 +211,10 @@ $grid-breakpoints: (
 // Define the maximum width of `.container` for different screen sizes.
 
 $container-max-widths: (
-        sm: 540px,
-        md: 720px,
-        lg: 960px,
-        xl: 1140px
+        sm: 800px,
+        md: 980px,
+        lg: 1220px,
+        xl: 1400px
 ) !default;
 
 @include _assert-ascending($container-max-widths, "$container-max-widths");


### PR DESCRIPTION
Changing the default bootstrap grid size

| container max-width | From | To   |
|----|------|------|
| sm | 540  | 800  |
| md | 720  | 980  |
| lg | 960  | 1220 |
| xl | 1140 | 1400 |