### PR TITLE
Improvement/Use same material icon size than v1

### DIFF
--- a/scss/material_icons/material_icons.scss
+++ b/scss/material_icons/material_icons.scss
@@ -1,1 +1,3 @@
+$material-icons-font-size: inherit;
+
 @import 'node_modules/material-icons/iconfont/filled.scss';


### PR DESCRIPTION
Dans la v1, on avait pas la font-size de set dans le scss.
Dans la v2, la lib met 24px.

Pour garder la même taille que la v1 j'override avec inherit. Ainsi les icônes ne changent pas de taille sur le core.