### PR TITLE
Improvement/Display error message after select 2

### DIFF
--- a/scss/plugins/select2.scss
+++ b/scss/plugins/select2.scss
@@ -352,3 +352,7 @@ span.select2-selection.select2-selection--single {
     border-color: $form-feedback-invalid-color !important;
   }
 }
+
+.select2.is-invalid ~ .invalid-feedback {
+  display: block;
+}


### PR DESCRIPTION
Les invalid-feedback sont en display none par défaut.

Y a une regle css 
```
.form-control.is-invalid ~ .invalid-feedback {
```

Je fais la meme avec le container select2.