### PR TITLE
Fix/Code color in variable scss

### DIFF
--- a/scss/bootstrap/_variables.scss
+++ b/scss/bootstrap/_variables.scss
@@ -1115,7 +1115,7 @@ $close-text-shadow:                 0 1px 0 $white !default;
 // Code
 
 $code-font-size:                    87.5% !default;
-$code-color:                        $pink !default;
+$code-color:                        $blue-bright !default;
 
 $kbd-padding-y:                     .2rem !default;
 $kbd-padding-x:                     .4rem !default;


### PR DESCRIPTION
L'ancienne variable `$pink` était utilisé de manière anecdotique pour colorer les balises `code`. Suite au changement de couleur pour coller les picto, il est nécessaire d'adapter le style css

Avant correction : 

<img width="633" alt="image" src="https://github.com/weglot/design/assets/118731144/f6580e67-a5aa-4a5f-acc7-306c21fe736c">

Après correction : 
<img width="662" alt="image" src="https://github.com/weglot/design/assets/118731144/af9a0383-55ae-4bbd-b363-d455b7d1bbe6">
