### PR TITLE
Fix/Code mirror scss

### DIFF
--- a/scss/plugins/codemirror.scss
+++ b/scss/plugins/codemirror.scss
@@ -32,12 +32,20 @@
 }
 /** Overwrite for base16-light theme */
 
-.CodeMirror .cm-s-base16-light {
+.CodeMirror.cm-s-base16-light {
     background-color: $grayish;
     max-height: 100% !important;
+
+    &.CodeMirror-empty {
+        color: $gray-500;
+    }
 }
 
 .cm-s-base16-light {
+    .CodeMirror-gutters {
+        background-color: $grayish;
+    }
+
     span.cm-tag {
         color: $blue-bright !important;
     }


### PR DESCRIPTION
<img width="1110" alt="image" src="https://github.com/weglot/design/assets/9052536/d3744464-b7fc-42f2-9225-d0e5d9239b32">

Sinon, avec juste
```
.CodeMirror.cm-s-base16-light {
    &.CodeMirror-empty {
        color: $gray-500;
    }
}
```
<img width="1098" alt="image" src="https://github.com/weglot/design/assets/9052536/7d15b47a-e62f-4b80-9017-0ca562e0cbaf">
