### PR TITLE
Quality/Stop using division without calc

### DIFF
--- a/scss/bootstrap/_variables.scss
+++ b/scss/bootstrap/_variables.scss
@@ -490,16 +490,16 @@ $input-plaintext-color: $blue;
 
 $input-height-border: $input-border-width * 2 !default;
 
-$input-height-inner: calc(#{$input-line-height * 1em} + #{$input-padding-y * 2}) !default;
-$input-height-inner-half: calc(#{$input-line-height * 0.5em} + #{$input-padding-y}) !default;
-$input-height-inner-quarter: calc(#{$input-line-height * 0.25em} + #{$input-padding-y / 2}) !default;
+$input-height-inner: calc(#{$input-line-height} * 1em + #{$input-padding-y} * 2) !default;
+$input-height-inner-half: calc(#{$input-line-height} * 0.5em + #{$input-padding-y}) !default;
+$input-height-inner-quarter: calc(#{$input-line-height} * 0.25em + #{$input-padding-y} / 2) !default;
 
-$input-height: calc(#{$input-line-height * 1em} + #{$input-padding-y * 2} + #{$input-height-border}) !default;
+$input-height: calc(#{$input-line-height} * 1em + #{$input-padding-y} * 2 + #{$input-height-border}) !default;
 $input-height-sm: calc(
-    #{$input-line-height-sm * 1em} + #{$input-btn-padding-y-sm * 2} + #{$input-height-border}
+    #{$input-line-height-sm} * 1em + #{$input-btn-padding-y-sm} * 2 + #{$input-height-border}
 ) !default;
 $input-height-lg: calc(
-    #{$input-line-height-lg * 1em} + #{$input-btn-padding-y-lg * 2} + #{$input-height-border}
+    #{$input-line-height-lg} * 1em + #{$input-btn-padding-y-lg} * 2 + #{$input-height-border}
 ) !default;
 
 $input-transition:
@@ -580,9 +580,9 @@ $custom-radio-indicator-icon-checked: str-replace(
 ) !default;
 
 $custom-switch-width: $custom-control-indicator-size * 1.67;
-$custom-switch-indicator-border-radius: $custom-control-indicator-size / 2 !default;
+$custom-switch-indicator-border-radius: calc($custom-control-indicator-size / 2) !default;
 $custom-switch-indicator-size: calc(
-    #{$custom-control-indicator-size} - #{$custom-control-indicator-border-width * 4}
+    #{$custom-control-indicator-size} - #{$custom-control-indicator-border-width} * 4
 ) !default;
 
 $custom-select-padding-y: $input-padding-y !default;
@@ -608,7 +608,7 @@ $custom-select-background: $custom-select-indicator no-repeat right $custom-sele
     $custom-select-bg-size !default; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
 
 $custom-select-feedback-icon-padding-right: calc(
-    (1em + #{2 * $custom-select-padding-y}) * 3 / 4 + #{$custom-select-padding-x + $custom-select-indicator-padding}
+    (1em + #{$custom-select-padding-y} * 2) * 3 / 4 + #{$custom-select-padding-x} + #{$custom-select-indicator-padding}
 ) !default;
 $custom-select-feedback-icon-position: center right ($custom-select-padding-x + $custom-select-indicator-padding) !default;
 $custom-select-feedback-icon-size: $input-height-inner-half $input-height-inner-half !default;
@@ -743,11 +743,11 @@ $nav-pills-link-active-color: $component-active-color !default;
 $nav-pills-link-active-bg: $component-active-bg !default;
 
 $nav-divider-color: $gray-200 !default;
-$nav-divider-margin-y: $spacer / 2 !default;
+$nav-divider-margin-y: calc($spacer / 2) !default;
 
 // Navbar
 
-$navbar-padding-y: $spacer / 1.25;
+$navbar-padding-y: calc($spacer / 1.25);
 $navbar-padding-x: $spacer !default;
 
 $navbar-nav-link-padding-x: 1.25rem;
@@ -756,7 +756,7 @@ $navbar-brand-font-size: $font-size-lg !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
 $nav-link-height: $font-size-base * $line-height-base + $nav-link-padding-y * 2 !default;
 $navbar-brand-height: $navbar-brand-font-size * $line-height-base !default;
-$navbar-brand-padding-y: ($nav-link-height - $navbar-brand-height) / 2 !default;
+$navbar-brand-padding-y: calc(($nav-link-height - $navbar-brand-height) / 2) !default;
 
 $navbar-toggler-padding-y: 0.25rem !default;
 $navbar-toggler-padding-x: 0.75rem !default;
@@ -876,7 +876,7 @@ $card-shadow: null;
 
 $card-img-overlay-padding: 1.25rem !default;
 
-$card-group-margin: $grid-gutter-width / 2 !default;
+$card-group-margin: calc($grid-gutter-width / 2) !default;
 $card-deck-margin: $card-group-margin !default;
 
 $card-columns-count: 3 !default;


### PR DESCRIPTION
Ca évite des warning coté core du genre
```
 warn  in ./assets/styles/app.scss                                                                                                                                2:54:31 PM

Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 878, column 20 of file:///var/www/wg-app/node_modules/@weglot/design/scss/bootstrap/_variables.scss:878:20:
Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($grid-gutter-width, 2) or calc($grid-gutter-width / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

878 | $card-group-margin: $grid-gutter-width / 2 !default;


node_modules/@weglot/design/scss/bootstrap/_variables.scss 879:21  @import
node_modules/@weglot/design/scss/bootstrap/_base.scss 3:9          @import
node_modules/@weglot/design/scss/bootstrap/_bootstrap.scss 2:9     @import
node_modules/@weglot/design/scss/main.scss 4:9                     @import
assets/styles/app.scss 1:9                                         root stylesheet
```

Par contre il reste des warning du genre 
```
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 84, column 28 of file:///var/www/wg-app/node_modules/bootstrap/scss/vendor/_rfs.scss:84:28:
Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1, $rfs-rem-value) or calc(1 / $rfs-rem-value)

More info and automated migrator: https://sass-lang.com/d/slash-div

84 |       $fs: $fs / ($fs * 0 + 1 / $rfs-rem-value);


node_modules/bootstrap/scss/vendor/_rfs.scss 85:29              rfs()
node_modules/bootstrap/scss/vendor/_rfs.scss 199:3              font-size()
node_modules/@weglot/design/scss/bootstrap/_reboot.scss 57:5    @import
node_modules/@weglot/design/scss/bootstrap/_bootstrap.scss 6:9  @import
node_modules/@weglot/design/scss/main.scss 4:9                  @import
assets/styles/app.scss 1:9                                      root stylesheet
```

Qui porte directement sur bootstrap. Quand on regarde nos dépendances, elles sont pas du tout à jour sur ce repo
<img width="819" alt="image" src="https://github.com/weglot/design/assets/9052536/3c393345-b060-4510-87b7-7bf77694456e">
-> Pourquoi bootstrap est lock à 4.3.1 ? Depuis y a 4.6.2

Quid d'une issue pour bump les dépendances sur le repo design @floranpagliai ?
