### PR TITLE
Fix/Tooltip opacity and display headings size

### DIFF
--- a/scss/bootstrap/_variables.scss
+++ b/scss/bootstrap/_variables.scss
@@ -656,11 +656,11 @@ $headings-color: $blue; //TODO: Handle dark mode?
 // scss-docs-start display-headings
 $display-font-sizes: (
     1: 5rem,
-    2: 4.5rem,
-    3: 4rem,
-    4: 3.5rem,
-    5: 3rem,
-    6: 2.5rem,
+    2: 4rem,
+    3: 3rem,
+    4: 2rem,
+    5: 1rem,
+    6: 0.5rem,
 ) !default;
 
 $display-font-family: null !default;
@@ -1424,7 +1424,7 @@ $tooltip-max-width: 280px;
 $tooltip-color: var(--#{$prefix}body-bg) !default;
 $tooltip-bg: $blue;
 $tooltip-border-radius: var(--#{$prefix}border-radius) !default;
-$tooltip-opacity: 0.9 !default;
+$tooltip-opacity: 1;
 $tooltip-padding-y: $spacer * 0.25 !default;
 $tooltip-padding-x: $spacer * 0.5 !default;
 $tooltip-margin: null !default; // TODO: remove this in v6

--- a/scss/bootstrap/_variables.scss
+++ b/scss/bootstrap/_variables.scss
@@ -661,7 +661,7 @@ $display-font-sizes: (
     4: 2rem,
     5: 1rem,
     6: 0.5rem,
-) !default;
+);
 
 $display-font-family: null !default;
 $display-font-style: null !default;

--- a/styleguide/_docs/foundations/typography.html
+++ b/styleguide/_docs/foundations/typography.html
@@ -61,3 +61,10 @@ category: typography
 <p><small>This line of text is meant to be treated as fine print.</small></p>
 <p><strong>This line rendered as bold text.</strong></p>
 <p><em>This line rendered as italicized text.</em></p>
+
+<h1 class="display-1">Display 1</h1>
+<h1 class="display-2">Display 2</h1>
+<h1 class="display-3">Display 3</h1>
+<h1 class="display-4">Display 4</h1>
+<h1 class="display-4">Display 5</h1>
+<h1 class="display-4">Display 6</h1>


### PR DESCRIPTION
Avant/Après

<img width="585" alt="image" src="https://github.com/user-attachments/assets/b85a393c-6c35-4bd5-9c86-858576e49c8d">
<img width="812" alt="image" src="https://github.com/user-attachments/assets/70d05027-06fd-4504-810d-d8fd2de6c123">
